### PR TITLE
Use sushi git module hosted on github instead bitbucket

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sushi-grpc-api"]
 	path = sushi-grpc-api
-	url = git@bitbucket.org:mindswteam/sushi-grpc-api.git
+	url = ../sushi-grpc-api


### PR DESCRIPTION
First of all, thank you very much for open sourcing this cool generic UI. This makes debugging so much more efficient (before I was using grpcurl which was working but much more complicated)

I have a small suggestion to change the remote URL for the grpc API to the public github repo

This would make it easier for open source project to use this UI.